### PR TITLE
Add placeholder tests for geogan routers

### DIFF
--- a/test/geongan/test_fcompany.py
+++ b/test/geongan/test_fcompany.py
@@ -1,0 +1,6 @@
+import importlib
+
+class TestFCompany:
+    def test_import_router(self):
+        module = importlib.import_module("app.routers.geogan.fcompany")
+        assert hasattr(module, "router")

--- a/test/geongan/test_fdatabase.py
+++ b/test/geongan/test_fdatabase.py
@@ -1,0 +1,6 @@
+import importlib
+
+class TestFDatabase:
+    def test_import_router(self):
+        module = importlib.import_module("app.routers.geogan.fdatabase")
+        assert hasattr(module, "router")

--- a/test/geongan/test_fdept.py
+++ b/test/geongan/test_fdept.py
@@ -1,0 +1,6 @@
+import importlib
+
+class TestFDept:
+    def test_import_router(self):
+        module = importlib.import_module("app.routers.geogan.fdept")
+        assert hasattr(module, "router")

--- a/test/geongan/test_fdivision.py
+++ b/test/geongan/test_fdivision.py
@@ -1,0 +1,6 @@
+import importlib
+
+class TestFDivision:
+    def test_import_router(self):
+        module = importlib.import_module("app.routers.geogan.fdivision")
+        assert hasattr(module, "router")

--- a/test/geongan/test_ffiles_lainnya.py
+++ b/test/geongan/test_ffiles_lainnya.py
@@ -1,0 +1,6 @@
+import importlib
+
+class TestFFilesLainnya:
+    def test_import_router(self):
+        module = importlib.import_module("app.routers.geogan.ffiles_lainnya")
+        assert hasattr(module, "router")

--- a/test/geongan/test_ffiles_mutasi.py
+++ b/test/geongan/test_ffiles_mutasi.py
@@ -1,0 +1,6 @@
+import importlib
+
+class TestFFilesMutasi:
+    def test_import_router(self):
+        module = importlib.import_module("app.routers.geogan.ffiles_mutasi")
+        assert hasattr(module, "router")

--- a/test/geongan/test_fproses_mutasi.py
+++ b/test/geongan/test_fproses_mutasi.py
@@ -1,0 +1,6 @@
+import importlib
+
+class TestFProsesMutasi:
+    def test_import_router(self):
+        module = importlib.import_module("app.routers.geogan.fproses_mutasi")
+        assert hasattr(module, "router")

--- a/test/geongan/test_fstatus_mutasi.py
+++ b/test/geongan/test_fstatus_mutasi.py
@@ -1,0 +1,6 @@
+import importlib
+
+class TestFStatusMutasi:
+    def test_import_router(self):
+        module = importlib.import_module("app.routers.geogan.fstatus_mutasi")
+        assert hasattr(module, "router")


### PR DESCRIPTION
## Summary
- add placeholder tests for geogan router modules to verify router import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d23ac68832da17515e4de682ff5