### PR TITLE
Add API tests for dataset resources

### DIFF
--- a/test/geongan/test_dataset.py
+++ b/test/geongan/test_dataset.py
@@ -1,0 +1,48 @@
+from httpx import AsyncClient, ASGITransport
+
+from app.core.database import SessionLocal, Base, engine
+from app.main import app
+from app.routers.geongan import dataset as dataset_router
+from app.core.security import create_access_token
+from app.models.geongan.division import Division
+from app.models.geongan.company import Company
+import app.models as models  # ensure tables are registered
+
+app.include_router(dataset_router.router)
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_dataset():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    db.add(Company(id=1, kode1="CMP", description="Test Company", status_active=True))
+    db.add(Division(id=1, kode1="DIV", description="Test Division", company_id=1, status_active=True))
+    db.commit()
+    db.close()
+
+    token = create_access_token({
+        "username": "test_user",
+        "roles": ["ROLE_ADMIN"],
+    })
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        headers = {"Authorization": f"Bearer {token}"}
+        payload = {
+            "id": 1,
+            "kode1": "DS1",
+            "description": "Dataset test",
+            "division_id": 1,
+            "status_active": True,
+        }
+        response = await ac.post("/api/datasets", json=payload, headers=headers)
+        assert response.status_code == 200
+
+        response_get = await ac.get("/api/datasets", headers=headers)
+        assert response_get.status_code == 200
+        assert any(item["id"] == 1 for item in response_get.json())

--- a/test/geongan/test_dataset_file.py
+++ b/test/geongan/test_dataset_file.py
@@ -1,0 +1,53 @@
+from httpx import AsyncClient, ASGITransport
+
+from app.core.database import SessionLocal, Base, engine
+from app.main import app
+from app.routers.geongan import dataset_file as dataset_file_router
+from app.core.security import create_access_token
+from app.models.geongan.dataset import Dataset
+from app.models.geongan.division import Division
+from app.models.geongan.company import Company
+import app.models as models  # ensure tables are registered
+
+app.include_router(dataset_file_router.router)
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_dataset_file():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    db.add(Company(id=1, kode1="CMP", description="Test Company", status_active=True))
+    db.add(Division(id=1, kode1="DIV", description="Test Division", company_id=1, status_active=True))
+    db.add(Dataset(id=1, kode1="DS1", description="Dataset test", division_id=1, status_active=True))
+    db.commit()
+    db.close()
+
+    token = create_access_token({
+        "username": "test_user",
+        "roles": ["ROLE_ADMIN"],
+    })
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        headers = {"Authorization": f"Bearer {token}"}
+        payload = {
+            "id": 1,
+            "dataset_id": 1,
+            "file_name": "file.csv",
+            "file_type": "csv",
+            "jenis": "type",
+            "flag": "flag",
+            "description": "desc",
+            "kode1": "FILE1",
+        }
+        response = await ac.post("/api/dataset-files", json=payload, headers=headers)
+        assert response.status_code == 200
+
+        response_get = await ac.get("/api/dataset-files", headers=headers)
+        assert response_get.status_code == 200
+        assert any(item["id"] == 1 for item in response_get.json())

--- a/test/geongan/test_dataset_row.py
+++ b/test/geongan/test_dataset_row.py
@@ -1,0 +1,49 @@
+from httpx import AsyncClient, ASGITransport
+
+from app.core.database import SessionLocal, Base, engine
+from app.main import app
+from app.routers.geongan import dataset_row as dataset_row_router
+from app.core.security import create_access_token
+from app.models.geongan.dataset import Dataset
+from app.models.geongan.division import Division
+from app.models.geongan.company import Company
+import app.models as models  # ensure tables are registered
+
+app.include_router(dataset_row_router.router)
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_dataset_row():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    db.add(Company(id=1, kode1="CMP", description="Test Company", status_active=True))
+    db.add(Division(id=1, kode1="DIV", description="Test Division", company_id=1, status_active=True))
+    db.add(Dataset(id=1, kode1="DS1", description="Dataset test", division_id=1, status_active=True))
+    db.commit()
+    db.close()
+
+    token = create_access_token({
+        "username": "test_user",
+        "roles": ["ROLE_ADMIN"],
+    })
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        headers = {"Authorization": f"Bearer {token}"}
+        payload = {
+            "id": 1,
+            "dataset_id": 1,
+            "kode1": "ROW1",
+            "description": "Row test",
+        }
+        response = await ac.post("/api/dataset-rows", json=payload, headers=headers)
+        assert response.status_code == 200
+
+        response_get = await ac.get("/api/dataset-rows", headers=headers)
+        assert response_get.status_code == 200
+        assert any(item["id"] == 1 for item in response_get.json())


### PR DESCRIPTION
## Summary
- add async tests for dataset, dataset file, and dataset row endpoints

## Testing
- `TEST_DATABASE_URL=sqlite:///./test.db SECRET_KEY=secret ALGORITHM=HS256 ACCESS_TOKEN_EXPIRE_MINUTES=30 pytest test/geongan/test_dataset.py test/geongan/test_dataset_file.py test/geongan/test_dataset_row.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab545fc600832db638e0fd9f83d4fa