### PR TITLE
Add endpoint access and link resource modules

### DIFF
--- a/app/models/geongan/dataset.py
+++ b/app/models/geongan/dataset.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 from app.core.database import Base
+from app.models.geongan.link_resource import LinkResource
 
 
 class Dataset(Base):
@@ -34,15 +35,15 @@ class Dataset(Base):
     links_from = relationship(
         "Dataset",
         secondary="link_resources",
-        primaryjoin="Dataset.id == LinkResource.dataset_from_id",
-        secondaryjoin="Dataset.id == LinkResource.dataset_to_id",
+        primaryjoin="Dataset.id == LinkResource.fdatasetFrom",
+        secondaryjoin="Dataset.id == LinkResource.fdatasetTo",
         back_populates="links_to",
     )
     links_to = relationship(
         "Dataset",
         secondary="link_resources",
-        primaryjoin="Dataset.id == LinkResource.dataset_to_id",
-        secondaryjoin="Dataset.id == LinkResource.dataset_from_id",
+        primaryjoin="Dataset.id == LinkResource.fdatasetTo",
+        secondaryjoin="Dataset.id == LinkResource.fdatasetFrom",
         back_populates="links_from",
     )
     endpoint_accesses = relationship("EndpointAccess", back_populates="dataset")

--- a/app/models/geongan/endpoint_access.py
+++ b/app/models/geongan/endpoint_access.py
@@ -1,17 +1,27 @@
+from enum import IntEnum
+
 from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.orm import relationship
+
 from app.core.database import Base
+
+
+class EndpointType(IntEnum):
+    PUBLIC = 0
+    PRIVATE = 1
+    INTERNAL = 2
 
 
 class EndpointAccess(Base):
     __tablename__ = "endpoint_accesses"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    endpoint = Column(String(255), nullable=False)
-    dataset_id = Column(Integer, ForeignKey("datasets.id"))
-    endpoint_type = Column(String(50))
-    basic_auth = Column(String(255))
+    userBean = Column(Integer, ForeignKey("users.id"), nullable=False)
+    endpoint = Column(String(25), nullable=False)
+    fdatasetBean = Column(Integer, ForeignKey("datasets.id"), nullable=False)
+    endPointType = Column(Integer, nullable=False)
+    basicAuth = Column(String(750))
 
     user = relationship("User", back_populates="endpoint_accesses")
     dataset = relationship("Dataset", back_populates="endpoint_accesses")
+

--- a/app/models/geongan/link_resource.py
+++ b/app/models/geongan/link_resource.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, Integer, ForeignKey
+
 from app.core.database import Base
 
 
@@ -6,5 +7,6 @@ class LinkResource(Base):
     __tablename__ = "link_resources"
 
     id = Column(Integer, primary_key=True)
-    dataset_from_id = Column(Integer, ForeignKey("datasets.id"), nullable=False)
-    dataset_to_id = Column(Integer, ForeignKey("datasets.id"), nullable=False)
+    fdatasetFrom = Column(Integer, ForeignKey("datasets.id"), nullable=False)
+    fdatasetTo = Column(Integer, ForeignKey("datasets.id"), nullable=False)
+

--- a/app/repository/geongan/endpoint_access_repo.py
+++ b/app/repository/geongan/endpoint_access_repo.py
@@ -1,0 +1,26 @@
+from sqlalchemy.orm import Session
+
+from app.models.geongan.endpoint_access import EndpointAccess
+from app.schemas.geongan.endpoint_access import EndpointAccessCreate
+
+
+def create_endpoint_access(db: Session, endpoint_access_in: EndpointAccessCreate):
+    db_obj = EndpointAccess(**endpoint_access_in.model_dump())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_all_endpoint_access(db: Session):
+    return db.query(EndpointAccess).all()
+
+
+def get_endpoint_access(db: Session, access_id: int):
+    return db.query(EndpointAccess).filter(EndpointAccess.id == access_id).first()
+
+
+def delete_endpoint_access(db: Session, access_id: int):
+    db.query(EndpointAccess).filter(EndpointAccess.id == access_id).delete()
+    db.commit()
+

--- a/app/repository/geongan/link_resource_repo.py
+++ b/app/repository/geongan/link_resource_repo.py
@@ -1,0 +1,26 @@
+from sqlalchemy.orm import Session
+
+from app.models.geongan.link_resource import LinkResource
+from app.schemas.geongan.link_resource import LinkResourceCreate
+
+
+def create_link_resource(db: Session, link_resource_in: LinkResourceCreate):
+    db_obj = LinkResource(**link_resource_in.model_dump())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_all_link_resource(db: Session):
+    return db.query(LinkResource).all()
+
+
+def get_link_resource(db: Session, link_id: int):
+    return db.query(LinkResource).filter(LinkResource.id == link_id).first()
+
+
+def delete_link_resource(db: Session, link_id: int):
+    db.query(LinkResource).filter(LinkResource.id == link_id).delete()
+    db.commit()
+

--- a/app/routers/geongan/endpoint_access.py
+++ b/app/routers/geongan/endpoint_access.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.repository.geongan.endpoint_access_repo import (
+    create_endpoint_access,
+    get_all_endpoint_access,
+)
+from app.schemas.geongan.endpoint_access import (
+    EndpointAccessCreate,
+    EndpointAccessResponse,
+)
+from app.models.geongan.endpoint_access import EndpointAccess
+
+
+router = APIRouter(prefix="/api", tags=["endpoint_access"])
+
+
+@router.post("/endpoint-accesses", response_model=EndpointAccessResponse)
+def create_endpoint_access_endpoint(
+    payload: EndpointAccessCreate,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    if "ROLE_ADMIN" not in current_user["roles"]:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+    existing = db.query(EndpointAccess).filter_by(id=payload.id).first()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="ID already exists")
+    result = create_endpoint_access(db, payload)
+    return EndpointAccessResponse.model_validate(result)
+
+
+@router.get("/endpoint-accesses", response_model=list[EndpointAccessResponse])
+def read_all_endpoint_access(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    if "ROLE_ADMIN" not in current_user["roles"]:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+    return get_all_endpoint_access(db)
+

--- a/app/routers/geongan/link_resource.py
+++ b/app/routers/geongan/link_resource.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.core.security import get_current_user
+from app.repository.geongan.link_resource_repo import (
+    create_link_resource,
+    get_all_link_resource,
+)
+from app.schemas.geongan.link_resource import (
+    LinkResourceCreate,
+    LinkResourceResponse,
+)
+from app.models.geongan.link_resource import LinkResource
+
+
+router = APIRouter(prefix="/api", tags=["link_resource"])
+
+
+@router.post("/link-resources", response_model=LinkResourceResponse)
+def create_link_resource_endpoint(
+    payload: LinkResourceCreate,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    if "ROLE_ADMIN" not in current_user["roles"]:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+    existing = db.query(LinkResource).filter_by(id=payload.id).first()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="ID already exists")
+    result = create_link_resource(db, payload)
+    return LinkResourceResponse.model_validate(result)
+
+
+@router.get("/link-resources", response_model=list[LinkResourceResponse])
+def read_all_link_resource(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    if "ROLE_ADMIN" not in current_user["roles"]:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin only")
+    return get_all_link_resource(db)
+

--- a/app/schemas/geongan/endpoint_access.py
+++ b/app/schemas/geongan/endpoint_access.py
@@ -1,0 +1,37 @@
+from enum import IntEnum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class EndpointType(IntEnum):
+    PUBLIC = 0
+    PRIVATE = 1
+    INTERNAL = 2
+
+
+class EndpointAccessBase(BaseModel):
+    userBean: int
+    endpoint: str
+    fdatasetBean: int
+    endPointType: EndpointType
+    basicAuth: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+
+    @model_validator(mode="after")
+    def check_basic_auth(self):
+        if self.endPointType in (EndpointType.PRIVATE, EndpointType.INTERNAL) and not self.basicAuth:
+            raise ValueError("basicAuth required for PRIVATE or INTERNAL endpoints")
+        if self.endPointType == EndpointType.PUBLIC and self.basicAuth is not None:
+            raise ValueError("basicAuth must be null for PUBLIC endpoints")
+        return self
+
+
+class EndpointAccessCreate(EndpointAccessBase):
+    id: int
+
+
+class EndpointAccessResponse(EndpointAccessBase):
+    id: int
+

--- a/app/schemas/geongan/link_resource.py
+++ b/app/schemas/geongan/link_resource.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class LinkResourceBase(BaseModel):
+    fdatasetFrom: int
+    fdatasetTo: int
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LinkResourceCreate(LinkResourceBase):
+    id: int
+
+
+class LinkResourceResponse(LinkResourceBase):
+    id: int
+

--- a/test/geongan/test_endpoint_access.py
+++ b/test/geongan/test_endpoint_access.py
@@ -1,0 +1,53 @@
+from httpx import AsyncClient, ASGITransport
+
+from app.core.database import SessionLocal, Base, engine
+from app.main import app
+from app.routers.geongan import endpoint_access as endpoint_access_router
+from app.core.security import create_access_token
+from app.models.geongan.dataset import Dataset
+from app.models.geongan.division import Division
+from app.models.geongan.company import Company
+from app.models.auth.user import User
+import app.models as models  # ensure tables are registered
+
+app.include_router(endpoint_access_router.router)
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_endpoint_access():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    db.add(Company(id=1, kode1="CMP", description="Test Company", status_active=True))
+    db.add(Division(id=1, kode1="DIV", description="Test Division", company_id=1, status_active=True))
+    db.add(Dataset(id=1, kode1="DS1", description="Dataset test", division_id=1, status_active=True))
+    db.add(User(id=1, username="user1", email="user1@example.com", password="secret"))
+    db.commit()
+    db.close()
+
+    token = create_access_token({
+        "username": "test_user",
+        "roles": ["ROLE_ADMIN"],
+    })
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        headers = {"Authorization": f"Bearer {token}"}
+        payload = {
+            "id": 1,
+            "userBean": 1,
+            "endpoint": "/test",
+            "fdatasetBean": 1,
+            "endPointType": 0,
+        }
+        response = await ac.post("/api/endpoint-accesses", json=payload, headers=headers)
+        assert response.status_code == 200
+
+        response_get = await ac.get("/api/endpoint-accesses", headers=headers)
+        assert response_get.status_code == 200
+        assert any(item["id"] == 1 for item in response_get.json())
+

--- a/test/geongan/test_endpoint_access_router.py
+++ b/test/geongan/test_endpoint_access_router.py
@@ -1,0 +1,7 @@
+import importlib
+
+
+def test_import_endpoint_access_router():
+    module = importlib.import_module("app.routers.geongan.endpoint_access")
+    assert hasattr(module, "router")
+

--- a/test/geongan/test_link_resource.py
+++ b/test/geongan/test_link_resource.py
@@ -1,0 +1,50 @@
+from httpx import AsyncClient, ASGITransport
+
+from app.core.database import SessionLocal, Base, engine
+from app.main import app
+from app.routers.geongan import link_resource as link_resource_router
+from app.core.security import create_access_token
+from app.models.geongan.dataset import Dataset
+from app.models.geongan.division import Division
+from app.models.geongan.company import Company
+import app.models as models  # ensure tables are registered
+
+app.include_router(link_resource_router.router)
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_link_resource():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    db.add(Company(id=1, kode1="CMP", description="Test Company", status_active=True))
+    db.add(Division(id=1, kode1="DIV", description="Test Division", company_id=1, status_active=True))
+    db.add(Dataset(id=1, kode1="DS1", description="Dataset 1", division_id=1, status_active=True))
+    db.add(Dataset(id=2, kode1="DS2", description="Dataset 2", division_id=1, status_active=True))
+    db.commit()
+    db.close()
+
+    token = create_access_token({
+        "username": "test_user",
+        "roles": ["ROLE_ADMIN"],
+    })
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        headers = {"Authorization": f"Bearer {token}"}
+        payload = {
+            "id": 1,
+            "fdatasetFrom": 1,
+            "fdatasetTo": 2,
+        }
+        response = await ac.post("/api/link-resources", json=payload, headers=headers)
+        assert response.status_code == 200
+
+        response_get = await ac.get("/api/link-resources", headers=headers)
+        assert response_get.status_code == 200
+        assert any(item["id"] == 1 for item in response_get.json())
+

--- a/test/geongan/test_link_resource_router.py
+++ b/test/geongan/test_link_resource_router.py
@@ -1,0 +1,7 @@
+import importlib
+
+
+def test_import_link_resource_router():
+    module = importlib.import_module("app.routers.geongan.link_resource")
+    assert hasattr(module, "router")
+


### PR DESCRIPTION
## Summary
- add EndpointAccess and LinkResource models with new fields
- expose CRUD routes and repositories for both resources
- cover endpoint access and link resource APIs with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab576c558c832d93a70fdadb292036